### PR TITLE
Revert "Nickname link: inline width"

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -945,7 +945,7 @@ class _NiconicoLivePageWidgetState extends State<NiconicoLivePageWidget> {
                       children: <Widget>[
                         Padding(padding: const EdgeInsets.all(8.0), child: SelectableText('${chatMessage.chatMessage.no}')),
                         icon,
-                        Column(crossAxisAlignment: CrossAxisAlignment.start, children: [Padding(padding: const EdgeInsets.all(8.0), child: name)]),
+                        Padding(padding: const EdgeInsets.all(8.0), child: name),
                         Padding(padding: const EdgeInsets.all(8.0), child: commentedAt),
                         Padding(padding: const EdgeInsets.all(8.0), child: content),
                       ],


### PR DESCRIPTION
Reverts aoirint/uguisu#22

Text selection region become too narrow. Rollback.
